### PR TITLE
fix(security): Add CSRF token to plan deletion form

### DIFF
--- a/app/templates/planner/index.html
+++ b/app/templates/planner/index.html
@@ -62,6 +62,7 @@
                                             <li><hr class="dropdown-divider"></li>
                                             <li>
                                                 <form action="{{ url_for('planner.delete_plan', plan_id=plan.id) }}" method="post" class="d-inline" onsubmit="return confirm('Are you sure you want to delete this travel plan?');">
+                                                    <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                                     <button type="submit" class="dropdown-item text-danger">Delete</button>
                                                 </form>
                                             </li>


### PR DESCRIPTION
This commit addresses a security vulnerability where plan deletion operations were failing with 'Bad Request - The CSRF token is missing' errors. The fix:

- Added hidden CSRF token field to the plan deletion form in index.html
- Ensures proper CSRF validation during plan deletion operations
- Prevents cross-site request forgery attacks against deletion endpoints
- Maintains consistent security practices across the application

Without this token, deletion operations were being rejected by Flask's CSRF protection middleware as potential cross-site request forgery attempts.